### PR TITLE
Replace Thread.sleep with Context.pause

### DIFF
--- a/src/main/java/totoro/unreality/Config.java
+++ b/src/main/java/totoro/unreality/Config.java
@@ -20,7 +20,7 @@ public class Config {
     public static String[] PLASMA_PERMEABLE_BLOCKS, PLASMA_EXPLOSIVE_BLOCKS, PLASMA_DESTRUCTIBLE_BLOCKS;
     public static double PLASMA_EXPLOSION_RADIUS = 1;
     // API
-    public static long PLASMA_UPGRADE_FIRE_DELAY = 200;
+    public static double PLASMA_UPGRADE_FIRE_DELAY = 0.2;
 
 
     public static void load(File file) {
@@ -62,9 +62,9 @@ public class Config {
                 "explosionRadius", 1,
                 "The size of plasma explosion.").getDouble();
 
-        PLASMA_UPGRADE_FIRE_DELAY = config.getInt("fireDelay",
-                "plasma", 200, 0, Integer.MAX_VALUE,
-                "Cooldown after each shot (milliseconds).");
+        PLASMA_UPGRADE_FIRE_DELAY = config.get("plasma",
+                "fireDelay", 0.2,
+                "Cooldown after each shot (seconds).").getDouble();
 
         if (config.hasChanged())
             config.save();

--- a/src/main/java/totoro/unreality/common/driver/DriverPlasmaUpgrade.java
+++ b/src/main/java/totoro/unreality/common/driver/DriverPlasmaUpgrade.java
@@ -68,7 +68,7 @@ public class DriverPlasmaUpgrade extends ManagedEnvironment implements DeviceInf
 
     @Callback(doc = "function(): boolean, [string] -- " +
             "Sets the color of the plasma-core. Returns true on success, " +
-            "false and an error message otherwise", limit = FIRE_CALL_LIMIT)
+            "false and an error message otherwise")
     public Object[] fire(Context context, Arguments args) {
         if(node.tryChangeBuffer(-Config.PLASMA_UPGRADE_FIRE_COST)) {
             // Generate and position in the world new entity (plasma bolt)
@@ -95,9 +95,7 @@ public class DriverPlasmaUpgrade extends ManagedEnvironment implements DeviceInf
             // Play blast sound
             bolt.playSound(Sounds.Blast, 1.0f, 1.0f);
             // Cooldown
-            try {
-                Thread.sleep(Config.PLASMA_UPGRADE_FIRE_DELAY);
-            } catch (InterruptedException e) {}
+            context.pause(Config.PLASMA_UPGRADE_FIRE_DELAY);
             return new Object[] { true };
         }
         return new Object[] { false, "not enough energy" };


### PR DESCRIPTION
I'm unsure why you used `Thread.sleep` (in the server thread, btw) instead of `Context.sleep`.

Also, I've removed the `limit` -- it limits the allowed call rate per tick and is kind of pointless in the callback.